### PR TITLE
RAND_status() returns 0 if we have do not supply a OSSL_RAND_PARAM_STATE

### DIFF
--- a/src/rand.h
+++ b/src/rand.h
@@ -20,6 +20,7 @@ typedef struct {
     OSRAND_PROV_CTX *provctx;
     /* Random device if device used */
     OSRAND_RANDOM_DEVICE rd;
+    int state;
 } OSRAND_RAND_CTX;
 
 int osrand_generate(void *vctx, unsigned char *buf, size_t buflen,


### PR DESCRIPTION
Fix it by adding such state and also the  strength of the random number generator in bits.
fixes #1 